### PR TITLE
show side run for l-shape layout and reposition it

### DIFF
--- a/showroom/src/three/KitchenScene.tsx
+++ b/showroom/src/three/KitchenScene.tsx
@@ -108,7 +108,8 @@ function Kitchen({ config }: { config: Configuration }) {
   const hardwareColor = hardware?.swatch || '#B5984F'
 
   const layout = config.layout
-  const showSideRun = layout === 'u-shape' || layout === 'island'
+  const showSideRun =
+    layout === 'l-shape' || layout === 'u-shape' || layout === 'island'
   const showIsland = layout === 'island'
 
   return (
@@ -138,7 +139,7 @@ function Kitchen({ config }: { config: Configuration }) {
       {showSideRun && (
         <>
           <CabinetRun
-            position={[-3.4, 0, -2.6]}
+            position={[-4.95, 0, 1.5]}
             length={4}
             cabColor={cabColor}
             counterColor={counterColor}


### PR DESCRIPTION
## Summary
- Include `l-shape` in the layouts that render the side cabinet run (previously only `u-shape` and `island`).
- Move the side run from `[-3.4, 0, -2.6]` to `[-4.95, 0, 1.5]` so it sits flush against the main run.

Touches `showroom/src/three/KitchenScene.tsx`, which is gated by the "no changes without review" stop-rule — opening this PR for that review.

## Test plan
- [ ] `cd showroom && npm run dev`, switch layout to **L-shape** and confirm the side run appears in the right place.
- [ ] Re-check **U-shape** and **Island** layouts for regressions in side-run placement.
- [ ] Re-check **Single-wall** has no side run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)